### PR TITLE
Fix editor warnings to use ScriptableObject.CreateInstance

### DIFF
--- a/Packages/com.sylan.audiomanager/Editor/AudioSettingEditor.cs
+++ b/Packages/com.sylan.audiomanager/Editor/AudioSettingEditor.cs
@@ -241,7 +241,7 @@ namespace Sylan.AudioManager
         }
     }
     [InitializeOnLoad]
-    public class AudioSettingInitialize : Editor, IVRCSDKBuildRequestedCallback
+    public class AudioSettingInitialize : IVRCSDKBuildRequestedCallback
     {
         private static int FindAudioZoneLayer()
         {

--- a/Packages/com.sylan.audiomanager/Editor/AudioSettingManagerEditor.cs
+++ b/Packages/com.sylan.audiomanager/Editor/AudioSettingManagerEditor.cs
@@ -6,7 +6,7 @@ using VRC.SDKBase.Editor.BuildPipeline;
 namespace Sylan.AudioManager
 {
     [InitializeOnLoad]
-    public class AudioSettingManagerInitialize : Editor, IVRCSDKBuildRequestedCallback
+    public class AudioSettingManagerInitialize : IVRCSDKBuildRequestedCallback
     {
         private static bool SetSerializedProperties()
         {

--- a/Packages/com.sylan.audiomanager/Editor/AudioZoneEditor.cs
+++ b/Packages/com.sylan.audiomanager/Editor/AudioZoneEditor.cs
@@ -241,7 +241,7 @@ namespace Sylan.AudioManager
         }
     }
     [InitializeOnLoad]
-    public class AudioZoneInitialize : Editor, IVRCSDKBuildRequestedCallback
+    public class AudioZoneInitialize : IVRCSDKBuildRequestedCallback
     {
         private static int FindAudioZoneLayer()
         {

--- a/Packages/com.sylan.audiomanager/Editor/AudioZoneManagerEditor.cs
+++ b/Packages/com.sylan.audiomanager/Editor/AudioZoneManagerEditor.cs
@@ -6,7 +6,7 @@ using VRC.SDKBase.Editor.BuildPipeline;
 namespace Sylan.AudioManager
 {
     [InitializeOnLoad]
-    public class AudioZoneManagerInitialize : Editor, IVRCSDKBuildRequestedCallback
+    public class AudioZoneManagerInitialize : IVRCSDKBuildRequestedCallback
     {
         private static bool SetSerializedProperties()
         {

--- a/Packages/com.sylan.audiomanager/Editor/SerializedPropertyUtils.cs
+++ b/Packages/com.sylan.audiomanager/Editor/SerializedPropertyUtils.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace Sylan.AudioManager.EditorUtilities
 {
-    public class SerializedPropertyUtils : Editor
+    public static class SerializedPropertyUtils
     {
         /// <summary>
         /// Find exactly one object of Type T in the scene hierarchy.
@@ -38,7 +38,7 @@ namespace Sylan.AudioManager.EditorUtilities
             return true;
         }
         /// <summary>
-        /// Set Serialized Property of Type T. Property must not be an array. 
+        /// Set Serialized Property of Type T. Property must not be an array.
         /// </summary>
         /// <typeparam name="T">Type of Object to set</typeparam>
         /// <param name="serializedObject">Object with the property</param>
@@ -64,7 +64,7 @@ namespace Sylan.AudioManager.EditorUtilities
         /// <param name="propertyName">Name of Serialized Property</param>
         public static void PopulateSerializedArray<T>(SerializedObject serializedObject, string propertyName) where T : MonoBehaviour
         {
-            if(serializedObject == null) return;
+            if (serializedObject == null) return;
             SerializedProperty arrayProperty;
             arrayProperty = serializedObject.FindProperty(propertyName);
 
@@ -95,7 +95,7 @@ namespace Sylan.AudioManager.EditorUtilities
                 EditorApplication.isPlaying = false;
                 return false;
             }
-            if(obj != null) serializedObject = new SerializedObject(obj);
+            if (obj != null) serializedObject = new SerializedObject(obj);
             return true;
         }
         /// <summary>


### PR DESCRIPTION
Example warning:
```
Sylan.AudioManager.AudioSettingManagerInitialize must be instantiated using the ScriptableObject.CreateInstance method instead of new AudioSettingManagerInitialize.
UnityEditor.Editor:.ctor ()
Sylan.AudioManager.AudioSettingManagerInitialize:.ctor ()
System.Activator:CreateInstance (System.Type)
VRC.SDKBase.Editor.BuildPipeline.VRCBuildPipelineCallbacks:Initialize ()
UnityEditor.EditorAssemblies:ProcessInitializeOnLoadMethodAttributes ()
```
This was caused by classes deriving from the `Editor` class as well as implementing the `IVRCSDKBuildRequestedCallback` interface. The `Editor` base class is specifically used for implementing custom inspectors, which was not the case here.

(Yes this is copy paste from the PR over in the GM menu since both packages are affected the same way)